### PR TITLE
DBから取得する最大件数を設定で変えられるように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
           "type": "string",
           "default": "http://localhost:8000",
           "description": "VectorDB のエンドポイントを指定します。"
+        },
+        "devInsights.documentVectorDB.maxResults": {
+          "type": "number",
+          "default": 5,
+          "description": "VectorDB から取得する最大結果数を指定します。"
         }
       }
     },

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -6,3 +6,7 @@ export const DB_ENDPOINT: string = config.get(
   "documentVectorDB.endpoint",
   "http://localhost:8000",
 );
+export const MAX_RESULTS: number = config.get(
+  "documentVectorDB.maxResults",
+  5,
+);

--- a/src/usecases/generateAnswer.ts
+++ b/src/usecases/generateAnswer.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { sendRequest } from "../copilot/sendRequest";
 import { VectorDBClient } from "../db-clients/vectorDBClient";
+import { MAX_RESULTS } from "../settings/settings";
 
 /**
  * ユーザーの質問に対する回答を生成する関数
@@ -16,7 +17,7 @@ export const generateAnswer = async (
   token: vscode.CancellationToken,
 ): Promise<void> => {
   // ベクトルDBから関連するドキュメントを検索
-  const vectorResults = await vectorDB.searchDocuments(prompt, 5);
+  const vectorResults = await vectorDB.searchDocuments(prompt, MAX_RESULTS);
 
   // 言語モデルのためのメッセージを準備
   const messages = [


### PR DESCRIPTION
## 対応内容

ベクトルDBから取得されるデータが大きすぎるとCopilotの制限に引っかかってしまうので、取得する結果の件数を設定で変えられるように変更