### PR TITLE
add support for additional models and refactor model selection

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Virtual Display (Xvfb)
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb=2:21.1.12-1ubuntu1.2
+          sudo apt-get install -y xvfb
           Xvfb :99 -screen 0 1024x768x24 &
 
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 | ベンダー       | モデル名 |
 | -------------- | -------- |
 | GitHub Copilot | `gpt-4o` |
+| GitHub Copilot | `gpt-4o-mini` |
+| GitHub Copilot | `claude-3.5-sonnet` |
 
 ## サポートするベクターDB
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,16 @@
           "type": "number",
           "default": 5,
           "description": "VectorDB から取得する最大結果数を指定します。"
+        },
+        "devInsights.modelName": {
+          "type": "string",
+          "enum": [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "claude-3.5-sonnet"
+          ],
+          "default": "gpt-4o",
+          "description": "使用するモデルの名前を指定します。"
         }
       }
     },

--- a/src/copilot/sendRequest.ts
+++ b/src/copilot/sendRequest.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { MODEL_NAME } from "../settings/settings";
 
 /**
  * GitHub Copilot にリクエストを送信する関数
@@ -12,7 +13,7 @@ export const sendRequest = async (
 ): Promise<vscode.LanguageModelChatResponse> => {
   const [model] = await vscode.lm.selectChatModels({
     vendor: "copilot",
-    family: "gpt-4o",
+    family: MODEL_NAME
   });
 
   const chatResponse = await model.sendRequest(messages, {}, token);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,3 +10,7 @@ export const MAX_RESULTS: number = config.get(
   "documentVectorDB.maxResults",
   5,
 );
+export const MODEL_NAME: string = config.get(
+  "modelName",
+  "gpt-4o",
+);


### PR DESCRIPTION
This pull request introduces support for additional AI models in the project and updates the configuration to make the model selection dynamic. The key changes include adding new models to the documentation and configuration, modifying the code to use a configurable model name, and introducing a new constant for the model name in the settings.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R19): Added `gpt-4o-mini` and `claude-3.5-sonnet` as supported models in the documentation.

### Configuration updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29-R38): Added a new configuration option, `devInsights.modelName`, allowing users to specify the model name with options `gpt-4o`, `gpt-4o-mini`, and `claude-3.5-sonnet`. The default value is set to `gpt-4o`.

### Code updates for dynamic model selection:
* [`src/settings/settings.ts`](diffhunk://#diff-9c9d24790e2b8d4f03202dc4d12f8918030d8398322460bb5dd2b74a06a369edR13-R16): Introduced a new constant, `MODEL_NAME`, to retrieve the model name from the configuration, with a default value of `gpt-4o`.
* [`src/copilot/sendRequest.ts`](diffhunk://#diff-024339360e53b04093635851cfb9b3b2fac75ae78b0d159998934f57508b096bR2): Updated the `sendRequest` function to dynamically use the `MODEL_NAME` constant for selecting the AI model family instead of the hardcoded `gpt-4o`. Also added an import for `MODEL_NAME`. [[1]](diffhunk://#diff-024339360e53b04093635851cfb9b3b2fac75ae78b0d159998934f57508b096bR2) [[2]](diffhunk://#diff-024339360e53b04093635851cfb9b3b2fac75ae78b0d159998934f57508b096bL15-R16)